### PR TITLE
bump go version to v1.22

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           components: rustfmt, clippy
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           toolchain: stable
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - uses: actions/cache@v3
         with:
           path: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo contains both Rust and Go code. The rust code is compiled into a dll/s
 
 ## Support Platform
 
-Requires Rust 1.77+ and Go 1.21.5+.
+Requires Rust 1.77+ and Go 1.22+.
 
 The Rust implementation of the VM is compiled to a library called libmovevm. This is then linked to the Go code when the final binary is built. For that reason not all systems supported by Go are supported by this project.
 

--- a/builders/Dockerfile.alpine
+++ b/builders/Dockerfile.alpine
@@ -2,7 +2,7 @@
 # 1. Build the static Rust library
 # 2. Execute Go tests that use and test this library
 # For 2. we define the Go image here. For 1. we install Rust below.
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/initia-labs/movevm
 
-go 1.21.5
+go 1.22
 
 require (
 	github.com/aptos-labs/serde-reflection/serde-generate/runtime/golang v0.0.0-20231213012317-73b6bbf74833


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Updated required Go version to 1.22+ for improved compatibility.
    - Switched base image to `golang:1.22-alpine` for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->