### PR TITLE
fix: return error not assert and charge memo gas

### DIFF
--- a/crates/natives/src/cosmos.rs
+++ b/crates/natives/src/cosmos.rs
@@ -327,6 +327,8 @@ fn native_nft_transfer(
     debug_assert!(arguments.len() == 10);
 
     let memo = safely_pop_arg!(arguments, Vector).to_vec_u8()?;
+    context.charge(gas_params.per_byte * NumBytes::new(memo.len() as u64))?;
+
     let timeout_timestamp = safely_pop_arg!(arguments, u64);
     let revision_height = safely_pop_arg!(arguments, u64);
     let revision_number = safely_pop_arg!(arguments, u64);

--- a/crates/natives/src/table.rs
+++ b/crates/natives/src/table.rs
@@ -683,10 +683,10 @@ fn native_next_box(
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut iterators = table_context.iterators.borrow_mut();
     let iterator = iterators.get_mut(iterator_id).unwrap();
+    let (key, value) = iterator.next.take().ok_or_else(|| {
+        partial_extension_error("next_box called without prepare_box")
+    })?;
 
-    assert!(iterator.next.is_some());
-
-    let (key, value) = iterator.next.take().unwrap();
     iterator.next = None;
 
     Ok(smallvec![key, value])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and flow control in the `native_next_box` function in `table.rs`.
- **Refactor**
	- Enhanced gas charge calculation based on the `memo` field length in the `native_nft_transfer` function in `cosmos.rs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->