### PR TITLE
check if the results are valid utf8

### DIFF
--- a/precompile/modules/initia_stdlib/sources/from_bcs.move
+++ b/precompile/modules/initia_stdlib/sources/from_bcs.move
@@ -106,6 +106,7 @@ module initia_std::from_bcs {
     use std::address;
 
     #[test]
+    #[expected_failure(abort_code = EINVALID_UTF8)]
     fun zellic_invalid_utf8_to_vector_string() {
         let invalid_utf8 = b"\x01\x03\xE0\x80\x80";
         let res = to_vector_string(invalid_utf8);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added UTF-8 validation checks to the `to_vector_string` function in the `initia_std::from_bcs` module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->