### PR TITLE
add clear error message to give more information at out of gas

### DIFF
--- a/crates/gas/src/meter.rs
+++ b/crates/gas/src/meter.rs
@@ -224,7 +224,7 @@ impl InitiaGasMeter {
 
     #[inline]
     fn charge(&mut self, amount: InternalGas) -> PartialVMResult<()> {
-        // copy the value to make error message more informative
+        // copy the value for error message
         let balance = self.balance;
 
         match self.balance.checked_sub(amount) {
@@ -234,11 +234,15 @@ impl InitiaGasMeter {
             }
             None => {
                 self.balance = 0.into();
-                Err(PartialVMError::new(StatusCode::OUT_OF_GAS).with_message(format!(
-                    "gas_limit: {}, gas_used: {}",
-                    self.gas_limit,
-                    self.gas_limit.checked_sub(balance).unwrap() + amount
-                )))
+                let gas_used: Gas = (self.gas_limit.checked_sub(balance).unwrap() + amount)
+                    .to_unit_round_down_with_params(&self.gas_params.txn);
+
+                Err(
+                    PartialVMError::new(StatusCode::OUT_OF_GAS).with_message(format!(
+                        "gas_limit: {}, gas_used: {}",
+                        self.gas_limit, gas_used
+                    )),
+                )
             }
         }
     }

--- a/crates/gas/src/meter.rs
+++ b/crates/gas/src/meter.rs
@@ -224,6 +224,9 @@ impl InitiaGasMeter {
 
     #[inline]
     fn charge(&mut self, amount: InternalGas) -> PartialVMResult<()> {
+        // copy the value to make error message more informative
+        let balance = self.balance;
+
         match self.balance.checked_sub(amount) {
             Some(new_balance) => {
                 self.balance = new_balance;
@@ -231,7 +234,11 @@ impl InitiaGasMeter {
             }
             None => {
                 self.balance = 0.into();
-                Err(PartialVMError::new(StatusCode::OUT_OF_GAS))
+                Err(PartialVMError::new(StatusCode::OUT_OF_GAS).with_message(format!(
+                    "gas_limit: {}, gas_used: {}",
+                    self.gas_limit,
+                    self.gas_limit.checked_sub(balance).unwrap() + amount
+                )))
             }
         }
     }

--- a/crates/natives/src/crypto/ed25519.rs
+++ b/crates/natives/src/crypto/ed25519.rs
@@ -178,7 +178,9 @@ pub fn native_batch_verify(
     } else if public_keys_len == 1 && messages_len == signatures_len {
         public_keys = repeats_vec_of_vec_u8(public_keys[0].to_vec(), signatures_len);
     } else {
-        return Err(SafeNativeError::Abort { abort_code: NUMBER_OF_ARGUMENTS_MISMATCH });
+        return Err(SafeNativeError::Abort {
+            abort_code: NUMBER_OF_ARGUMENTS_MISMATCH,
+        });
     }
 
     debug_assert_eq!(messages.len(), signatures_len);

--- a/libmovevm/src/error/rust.rs
+++ b/libmovevm/src/error/rust.rs
@@ -1,6 +1,6 @@
 use errno::{set_errno, Errno};
 use initia_move_types::errors::BackendError;
-use move_core_types::vm_status::VMStatus;
+use move_core_types::vm_status::{StatusCode, VMStatus};
 use thiserror::Error;
 
 use crate::memory::UnmanagedVector;

--- a/libmovevm/src/error/rust.rs
+++ b/libmovevm/src/error/rust.rs
@@ -1,6 +1,6 @@
 use errno::{set_errno, Errno};
 use initia_move_types::errors::BackendError;
-use move_core_types::vm_status::{StatusCode, VMStatus};
+use move_core_types::vm_status::VMStatus;
 use thiserror::Error;
 
 use crate::memory::UnmanagedVector;


### PR DESCRIPTION
VM will return 
```
"VM error: status OUT_OF_GAS of type Execution with message gas_limit: 100, gas_used: 500000" should not contain "OUT_OF_GAS"
```

error message at out of gas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Enhanced error messages to include detailed gas limit and usage information when running out of gas.
  
- **Improvements**
  - Improved error handling by importing additional status codes for more precise error reporting.
- **Refactor**
  - Updated the `native_batch_verify` function to return structured errors with explicit `abort_code` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->