### PR TITLE
fix: remove unnecessary object stores

### DIFF
--- a/precompile/modules/initia_stdlib/sources/table.move
+++ b/precompile/modules/initia_stdlib/sources/table.move
@@ -224,7 +224,7 @@ module initia_std::table {
         (key, &mut box.val)
     }
 
-    public fun get_last_element<K: copy + drop, V>(table: &mut Table<K,V>): (K,&V) {
+    public fun get_last_key_and_value<K: copy + drop, V>(table: &mut Table<K,V>): (K,&V) {
         let iter = iter(
             table,
             option::none(),

--- a/precompile/modules/initia_stdlib/sources/table.move
+++ b/precompile/modules/initia_stdlib/sources/table.move
@@ -224,7 +224,7 @@ module initia_std::table {
         (key, &mut box.val)
     }
 
-    public fun get_last_key_and_value<K: copy + drop, V>(table: &mut Table<K,V>): (K,&V) {
+    public inline fun get_last_key_and_value<K: copy + drop, V>(table: &mut Table<K,V>): (K,&V) {
         let iter = iter(
             table,
             option::none(),
@@ -232,9 +232,11 @@ module initia_std::table {
             2
         );
         if(!prepare<K, V>(&mut iter)) {
-            abort(error::invalid_argument(ENOT_FOUND));
+            abort(error::invalid_argument(ENOT_FOUND))
         };
-        next<K,V>(&mut iter)
+        let(key, value) = next<K,V>(&mut iter);
+
+        (key, value)
     }
 
     // ======================================================================================================

--- a/precompile/modules/initia_stdlib/sources/table.move
+++ b/precompile/modules/initia_stdlib/sources/table.move
@@ -224,6 +224,19 @@ module initia_std::table {
         (key, &mut box.val)
     }
 
+    public fun get_last_element<K: copy + drop, V>(table: &mut Table<K,V>): (K,&V) {
+        let iter = iter(
+            table,
+            option::none(),
+            option::none(),
+            2
+        );
+        if(!prepare<K, V>(&mut iter)) {
+            abort(error::invalid_argument(ENOT_FOUND));
+        };
+        next<K,V>(&mut iter)
+    }
+
     // ======================================================================================================
     // Internal API
 

--- a/precompile/modules/initia_stdlib/sources/vip/operator.move
+++ b/precompile/modules/initia_stdlib/sources/vip/operator.move
@@ -31,12 +31,7 @@ module publisher::vip_operator {
     struct ModuleStore has key {
         operator_data: Table<vector<u8> /*bridge id key*/, OperatorInfo>
     }
-    struct ModuleStore has key {
-        operator_data: Table<vector<u8> /*bridge id key*/, OperatorInfo>
-    }
 
-    struct OperatorInfo has store {
-        operator_addr: address,
     struct OperatorInfo has store {
         operator_addr: address,
         last_changed_stage: u64,
@@ -49,8 +44,6 @@ module publisher::vip_operator {
     // Responses
     //
 
-    struct OperatorInfoResponse has drop {
-        operator_addr: address,
     struct OperatorInfoResponse has drop {
         operator_addr: address,
         last_changed_stage: u64,
@@ -140,18 +133,6 @@ module publisher::vip_operator {
             &commission_max_rate,
             &commission_max_change_rate,
             &commission_rate
-        );
-
-        table::add<vector<u8>, OperatorInfo>(
-            &mut module_store.operator_data,
-            bridge_id_key,
-            OperatorInfo {
-                operator_addr: operator_addr,
-                last_changed_stage: stage,
-                commission_max_rate,
-                commission_max_change_rate,
-                commission_rate,
-            }
         );
 
         table::add<vector<u8>, OperatorInfo>(

--- a/precompile/modules/initia_stdlib/sources/vip/operator.move
+++ b/precompile/modules/initia_stdlib/sources/vip/operator.move
@@ -201,7 +201,7 @@ module publisher::vip_operator {
         );
     }
 
-    entry public fun update_operator_addr(
+    public entry fun update_operator_addr(
         old_operator: &signer,
         bridge_id: u64,
         new_operator_addr: address,

--- a/precompile/modules/initia_stdlib/sources/vip/operator.move
+++ b/precompile/modules/initia_stdlib/sources/vip/operator.move
@@ -282,6 +282,7 @@ module publisher::vip_operator {
 
     #[test(publisher = @publisher, operator = @0x999)]
     fun test_update_operator_commission(publisher: &signer, operator: &signer) acquires ModuleStore {
+        init_module_for_test(publisher);
         let bridge_id = 1;
         let operator_addr = signer::address_of(operator);
 
@@ -346,6 +347,7 @@ module publisher::vip_operator {
     #[test(publisher = @publisher, operator = @0x999)]
     #[expected_failure(abort_code = 0x10003, location = Self)]
     fun failed_invalid_change_rate(publisher: &signer, operator: &signer) acquires ModuleStore {
+        init_module_for_test(publisher);
         let bridge_id = 1;
         let operator_addr = signer::address_of(operator);
 
@@ -370,6 +372,7 @@ module publisher::vip_operator {
     #[test(publisher = @publisher, operator = @0x999)]
     #[expected_failure(abort_code = 0x10004, location = Self)]
     fun failed_over_max_rate(publisher: &signer, operator: &signer) acquires ModuleStore {
+        init_module_for_test(publisher);
         let bridge_id = 1;
         let operator_addr = signer::address_of(operator);
 
@@ -394,6 +397,7 @@ module publisher::vip_operator {
     #[test(publisher = @publisher, operator = @0x999)]
     #[expected_failure(abort_code = 0x10005, location = Self)]
     fun failed_not_valid_stage(publisher: &signer, operator: &signer) acquires ModuleStore {
+        init_module_for_test(publisher);
         let bridge_id = 1;
         let operator_addr = signer::address_of(operator);
 
@@ -418,6 +422,7 @@ module publisher::vip_operator {
     #[test(publisher = @publisher, operator = @0x999)]
     #[expected_failure(abort_code = 0x10006, location = Self)]
     fun failed_invalid_commission_rate(publisher: &signer, operator: &signer) acquires ModuleStore {
+        init_module_for_test(publisher);
         let bridge_id = 1;
         let operator_addr = signer::address_of(operator);
 

--- a/precompile/modules/initia_stdlib/sources/vip/reward.move
+++ b/precompile/modules/initia_stdlib/sources/vip/reward.move
@@ -82,7 +82,6 @@ module publisher::vip_reward {
         operator_reward: u64
     ) acquires ModuleStore {
         let module_store = borrow_global_mut<ModuleStore>(@publisher);
-        let table_key = get_distrubuted_reward_table_key(bridge_id, stage);
         table::add(
             &mut module_store.distributed_reward,
             get_distrubuted_reward_table_key(bridge_id, stage),

--- a/precompile/modules/initia_stdlib/sources/vip/reward.move
+++ b/precompile/modules/initia_stdlib/sources/vip/reward.move
@@ -42,9 +42,7 @@ module publisher::vip_reward {
     // Resources
     //
 
-    struct RewardStore has key {
-        extend_ref: ExtendRef,
-        reward_store: Object<FungibleStore>,
+    struct ModuleStore has key {
         reward_per_stage: table::Table<vector<u8> /* stage */, u64>,
     }
 
@@ -63,152 +61,152 @@ module publisher::vip_reward {
     // Helper Functions
     //
 
-    fun generate_operator_reward_store_seed(bridge_id: u64): vector<u8> {
-        let seed = vector[OPERATOR_REWARD_PREFIX];
-        vector::append(
-            &mut seed,
-            bcs::to_bytes(&@publisher)
-        );
+    // fun generate_operator_reward_store_seed(bridge_id: u64): vector<u8> {
+    //     let seed = vector[OPERATOR_REWARD_PREFIX];
+    //     vector::append(
+    //         &mut seed,
+    //         bcs::to_bytes(&@publisher)
+    //     );
 
-        vector::append(
-            &mut seed,
-            bcs::to_bytes(&bridge_id)
-        );
-        return seed
-    }
+    //     vector::append(
+    //         &mut seed,
+    //         bcs::to_bytes(&bridge_id)
+    //     );
+    //     return seed
+    // }
 
-    fun generate_user_reward_store_seed(bridge_id: u64): vector<u8> {
-        let seed = vector[USER_REWARD_PREFIX];
-        vector::append(
-            &mut seed,
-            bcs::to_bytes(&@publisher)
-        );
+    // fun generate_user_reward_store_seed(bridge_id: u64): vector<u8> {
+    //     let seed = vector[USER_REWARD_PREFIX];
+    //     vector::append(
+    //         &mut seed,
+    //         bcs::to_bytes(&@publisher)
+    //     );
 
-        vector::append(
-            &mut seed,
-            bcs::to_bytes(&bridge_id)
-        );
-        return seed
-    }
+    //     vector::append(
+    //         &mut seed,
+    //         bcs::to_bytes(&bridge_id)
+    //     );
+    //     return seed
+    // }
 
-    fun create_operator_reward_store_address(bridge_id: u64): address {
-        let seed = generate_operator_reward_store_seed(bridge_id);
-        object::create_object_address(@publisher, seed)
-    }
+    // fun create_operator_reward_store_address(bridge_id: u64): address {
+    //     let seed = generate_operator_reward_store_seed(bridge_id);
+    //     object::create_object_address(@publisher, seed)
+    // }
 
-    fun create_user_reward_store_address(bridge_id: u64): address {
-        let seed = generate_user_reward_store_seed(bridge_id);
-        object::create_object_address(@publisher, seed)
-    }
+    // fun create_user_reward_store_address(bridge_id: u64): address {
+    //     let seed = generate_user_reward_store_seed(bridge_id);
+    //     object::create_object_address(@publisher, seed)
+    // }
 
-    //
-    // Friend Functions
-    //
+    // //
+    // // Friend Functions
+    // //
 
-    public(friend) fun register_operator_reward_store(chain: &signer, bridge_id: u64,) {
-        let seed = generate_operator_reward_store_seed(bridge_id);
-        let reward_store_addr = object::create_object_address(
-            signer::address_of(chain), seed
-        );
-        assert!(
-            !exists<RewardStore>(reward_store_addr),
-            error::already_exists(EREWARD_STORE_ALREADY_EXISTS)
-        );
+    // public(friend) fun register_operator_reward_store(chain: &signer, bridge_id: u64,) {
+    //     let seed = generate_operator_reward_store_seed(bridge_id);
+    //     let reward_store_addr = object::create_object_address(
+    //         signer::address_of(chain), seed
+    //     );
+    //     assert!(
+    //         !exists<RewardStore>(reward_store_addr),
+    //         error::already_exists(EREWARD_STORE_ALREADY_EXISTS)
+    //     );
 
-        let constructor_ref = object::create_named_object(chain, seed, false);
-        let object = object::generate_signer(&constructor_ref);
-        let extend_ref = object::generate_extend_ref(&constructor_ref);
-        let reward_store = primary_fungible_store::ensure_primary_store_exists(
-            reward_store_addr,
-            reward_metadata()
-        );
+    //     let constructor_ref = object::create_named_object(chain, seed, false);
+    //     let object = object::generate_signer(&constructor_ref);
+    //     let extend_ref = object::generate_extend_ref(&constructor_ref);
+    //     let reward_store = primary_fungible_store::ensure_primary_store_exists(
+    //         reward_store_addr,
+    //         reward_metadata()
+    //     );
 
-        move_to(
-            &object,
-            RewardStore {
-                extend_ref,
-                reward_store,
-                reward_per_stage: table::new<vector<u8>, u64>(),
-            }
-        );
-    }
+    //     move_to(
+    //         &object,
+    //         RewardStore {
+    //             extend_ref,
+    //             reward_store,
+    //             reward_per_stage: table::new<vector<u8>, u64>(),
+    //         }
+    //     );
+    // }
 
-    public(friend) fun register_user_reward_store(chain: &signer, bridge_id: u64,) {
-        let seed = generate_user_reward_store_seed(bridge_id);
-        let reward_store_addr = object::create_object_address(
-            signer::address_of(chain), seed
-        );
-        assert!(
-            !exists<RewardStore>(reward_store_addr),
-            error::already_exists(EREWARD_STORE_ALREADY_EXISTS)
-        );
+    // public(friend) fun register_user_reward_store(chain: &signer, bridge_id: u64,) {
+    //     let seed = generate_user_reward_store_seed(bridge_id);
+    //     let reward_store_addr = object::create_object_address(
+    //         signer::address_of(chain), seed
+    //     );
+    //     assert!(
+    //         !exists<RewardStore>(reward_store_addr),
+    //         error::already_exists(EREWARD_STORE_ALREADY_EXISTS)
+    //     );
 
-        let constructor_ref = object::create_named_object(chain, seed, false);
-        let object = object::generate_signer(&constructor_ref);
-        let extend_ref = object::generate_extend_ref(&constructor_ref);
-        let reward_store = primary_fungible_store::ensure_primary_store_exists(
-            reward_store_addr,
-            reward_metadata()
-        );
+    //     let constructor_ref = object::create_named_object(chain, seed, false);
+    //     let object = object::generate_signer(&constructor_ref);
+    //     let extend_ref = object::generate_extend_ref(&constructor_ref);
+    //     let reward_store = primary_fungible_store::ensure_primary_store_exists(
+    //         reward_store_addr,
+    //         reward_metadata()
+    //     );
 
-        move_to(
-            &object,
-            RewardStore {
-                extend_ref,
-                reward_store,
-                reward_per_stage: table::new<vector<u8>, u64>(),
-            }
-        );
-    }
+    //     move_to(
+    //         &object,
+    //         RewardStore {
+    //             extend_ref,
+    //             reward_store,
+    //             reward_per_stage: table::new<vector<u8>, u64>(),
+    //         }
+    //     );
+    // }
 
-    public(friend) fun add_reward_per_stage(
-        reward_store_addr: address,
-        stage: u64,
-        reward: u64
-    ) acquires RewardStore {
-        let reward_store = borrow_global_mut<RewardStore>(reward_store_addr);
-        let stage_reward = table::borrow_mut_with_default(
-            &mut reward_store.reward_per_stage,
-            table_key::encode_u64(stage),
-            0
-        );
-        *stage_reward = *stage_reward + reward;
-    }
+    // public(friend) fun add_reward_per_stage(
+    //     reward_store_addr: address,
+    //     stage: u64,
+    //     reward: u64
+    // ) acquires RewardStore {
+    //     let reward_store = borrow_global_mut<RewardStore>(reward_store_addr);
+    //     let stage_reward = table::borrow_mut_with_default(
+    //         &mut reward_store.reward_per_stage,
+    //         table_key::encode_u64(stage),
+    //         0
+    //     );
+    //     *stage_reward = *stage_reward + reward;
+    // }
 
-    public(friend) fun withdraw(
-        reward_store_addr: address,
-        amount: u64,
-    ): FungibleAsset acquires RewardStore {
-        let reward_store = borrow_global<RewardStore>(reward_store_addr);
-        let reward_signer = object::generate_signer_for_extending(&reward_store.extend_ref);
+    // public(friend) fun withdraw(
+    //     reward_store_addr: address,
+    //     amount: u64,
+    // ): FungibleAsset acquires RewardStore {
+    //     let reward_store = borrow_global<RewardStore>(reward_store_addr);
+    //     let reward_signer = object::generate_signer_for_extending(&reward_store.extend_ref);
 
-        fungible_asset::withdraw(
-            &reward_signer,
-            reward_store.reward_store,
-            amount
-        )
-    }
+    //     fungible_asset::withdraw(
+    //         &reward_signer,
+    //         reward_store.reward_store,
+    //         amount
+    //     )
+    // }
 
-    public(friend) fun penalty(
-        bridge_id: u64,
-        penalty_amount: u64,
-        vault_store_addr: address
-    ) acquires RewardStore {
-        let reward_store_addr = get_user_reward_store_address(bridge_id);
-        let reward_store = borrow_global<RewardStore>(reward_store_addr);
-        let reward_signer = object::generate_signer_for_extending(&reward_store.extend_ref);
-        assert!(
-            penalty_amount > 0,
-            error::invalid_argument(EPENALTY_AMOUNT)
-        );
+    // public(friend) fun penalty(
+    //     bridge_id: u64,
+    //     penalty_amount: u64,
+    //     vault_store_addr: address
+    // ) acquires RewardStore {
+    //     let reward_store_addr = get_user_reward_store_address(bridge_id);
+    //     let reward_store = borrow_global<RewardStore>(reward_store_addr);
+    //     let reward_signer = object::generate_signer_for_extending(&reward_store.extend_ref);
+    //     assert!(
+    //         penalty_amount > 0,
+    //         error::invalid_argument(EPENALTY_AMOUNT)
+    //     );
 
-        primary_fungible_store::transfer(
-            &reward_signer,
-            reward_metadata(),
-            vault_store_addr,
-            penalty_amount
-        );
-    }
+    //     primary_fungible_store::transfer(
+    //         &reward_signer,
+    //         reward_metadata(),
+    //         vault_store_addr,
+    //         penalty_amount
+    //     );
+    // }
 
     //
     // View Functions
@@ -223,51 +221,48 @@ module publisher::vip_reward {
     }
 
     #[view]
-    public fun get_stage_reward(
-        reward_store_addr: address,
-        stage: u64
-    ): u64 acquires RewardStore {
-        let reward_store = borrow_global<RewardStore>(reward_store_addr);
+    public fun get_stage_reward(stage: u64): u64 acquires ModuleStore {
+        let module_store = borrow_global<ModuleStore>(@publisher);
 
         let stage_reward = table::borrow_with_default(
-            &reward_store.reward_per_stage,
+            &module_store.reward_per_stage,
             table_key::encode_u64(stage),
             &0
         );
         *stage_reward
     }
 
-    #[view]
-    public fun is_operator_reward_store_registered(bridge_id: u64): bool {
-        exists<RewardStore>(
-            create_operator_reward_store_address(bridge_id)
-        )
-    }
+    // #[view]
+    // public fun is_operator_reward_store_registered(bridge_id: u64): bool {
+    //     exists<RewardStore>(
+    //         create_operator_reward_store_address(bridge_id)
+    //     )
+    // }
 
-    public fun is_user_reward_store_registered(bridge_id: u64): bool {
-        exists<RewardStore>(
-            create_user_reward_store_address(bridge_id)
-        )
-    }
+    // public fun is_user_reward_store_registered(bridge_id: u64): bool {
+    //     exists<RewardStore>(
+    //         create_user_reward_store_address(bridge_id)
+    //     )
+    // }
 
-    #[view]
-    public fun get_operator_reward_store_address(bridge_id: u64): address {
-        let reward_addr = create_operator_reward_store_address(bridge_id);
-        assert!(
-            exists<RewardStore>(reward_addr),
-            error::not_found(EREWARD_STORE_NOT_FOUND)
-        );
-        reward_addr
-    }
+    // #[view]
+    // public fun get_operator_reward_store_address(bridge_id: u64): address {
+    //     let reward_addr = create_operator_reward_store_address(bridge_id);
+    //     assert!(
+    //         exists<RewardStore>(reward_addr),
+    //         error::not_found(EREWARD_STORE_NOT_FOUND)
+    //     );
+    //     reward_addr
+    // }
 
-    #[view]
-    public fun get_user_reward_store_address(bridge_id: u64): address {
-        let reward_addr = create_user_reward_store_address(bridge_id);
-        assert!(
-            exists<RewardStore>(reward_addr),
-            error::not_found(EREWARD_STORE_NOT_FOUND)
-        );
-        reward_addr
-    }
+    // #[view]
+    // public fun get_user_reward_store_address(bridge_id: u64): address {
+    //     let reward_addr = create_user_reward_store_address(bridge_id);
+    //     assert!(
+    //         exists<RewardStore>(reward_addr),
+    //         error::not_found(EREWARD_STORE_NOT_FOUND)
+    //     );
+    //     reward_addr
+    // }
 
 }

--- a/precompile/modules/initia_stdlib/sources/vip/vault.move
+++ b/precompile/modules/initia_stdlib/sources/vip/vault.move
@@ -73,7 +73,7 @@ module publisher::vip_vault {
     // Friend Functions
     //
 
-    public(friend) fun withdraw(account_addr: address, amount: u64): FungibleAsset acquires ModuleStore {
+    public(friend) fun withdraw(amount: u64): FungibleAsset acquires ModuleStore {
         let module_store = borrow_global_mut<ModuleStore>(@publisher);
         assert!(
             module_store.reward_per_stage > 0,

--- a/precompile/modules/initia_stdlib/sources/vip/vault.move
+++ b/precompile/modules/initia_stdlib/sources/vip/vault.move
@@ -87,20 +87,6 @@ module publisher::vip_vault {
         fungible_asset::withdraw(&vault_signer, vault_store, amount)
     }
 
-    public(friend) fun withdraw(account_addr: address, amount: u64): FungibleAsset acquires ModuleStore {
-        let module_store = borrow_global_mut<ModuleStore>(@publisher);
-        assert!(
-            module_store.reward_per_stage > 0,
-            error::invalid_state(EINVALID_REWARD_PER_STAGE)
-        );
-        let vault_signer = object::generate_signer_for_extending(&module_store.extend_ref);
-        let vault_store = primary_fungible_store::ensure_primary_store_exists(
-            module_store.vault_store_addr,
-            vip_reward::reward_metadata()
-        );
-        fungible_asset::withdraw(&vault_signer, vault_store, amount)
-    }
-
     //
     // Entry Functions
     //

--- a/precompile/modules/initia_stdlib/sources/vip/vault.move
+++ b/precompile/modules/initia_stdlib/sources/vip/vault.move
@@ -8,7 +8,7 @@ module publisher::vip_vault {
     use initia_std::fungible_asset;
     use publisher::vip_reward;
 
-    friend publisher::vip;
+    // friend publisher::vip;
     friend publisher::vip_vesting;
     //
     // Errors
@@ -79,6 +79,7 @@ module publisher::vip_vault {
         borrow_global<ModuleStore>(@publisher).vault_store_addr
     }
 
+    // IS IT NEED?
     public(friend) fun claim(stage: u64,): FungibleAsset acquires ModuleStore {
         let module_store = borrow_global_mut<ModuleStore>(@publisher);
         assert!(
@@ -101,6 +102,20 @@ module publisher::vip_vault {
             vault_store,
             module_store.reward_per_stage
         )
+    }
+
+    public(friend) fun withdraw(account_addr: address, amount: u64): FungibleAsset acquires ModuleStore {
+        let module_store = borrow_global_mut<ModuleStore>(@publisher);
+        assert!(
+            module_store.reward_per_stage > 0,
+            error::invalid_state(EINVALID_REWARD_PER_STAGE)
+        );
+        let vault_signer = object::generate_signer_for_extending(&module_store.extend_ref);
+        let vault_store = primary_fungible_store::ensure_primary_store_exists(
+            module_store.vault_store_addr,
+            vip_reward::reward_metadata()
+        );
+        fungible_asset::withdraw(&vault_signer, vault_store, amount)
     }
 
     //

--- a/precompile/modules/initia_stdlib/sources/vip/vesting.move
+++ b/precompile/modules/initia_stdlib/sources/vip/vesting.move
@@ -194,20 +194,6 @@ module publisher::vip_vesting {
         remaining_reward: u64,
     }
 
-    // Table key
-    // get table key by bridge_id, account address,vesting start stage
-    fun get_vesting_table_key(bridge_id: u64, account_addr: address): vector<u8> {
-        let key = vector::empty<u8>();
-        vector::append(
-            &mut key,
-            table_key::encode_u64(bridge_id)
-        );
-        vector::append(
-            &mut key,
-            bcs::to_bytes(&account_addr)
-        );key
-    }
-
     fun init_module(chain: &signer) {
         move_to(
             chain,

--- a/precompile/modules/initia_stdlib/sources/vip/vesting.move
+++ b/precompile/modules/initia_stdlib/sources/vip/vesting.move
@@ -828,7 +828,7 @@ module publisher::vip_vesting {
             };
 
             // position finalized when stage is over the end stage or remaining reward is 0
-            if (claim_info.start_stage >= value.end_stage || value.remaining_reward == 0) {
+            if (claim_info.start_stage == value.end_stage || value.remaining_reward == 0) {
                 event::emit(
                     UserVestingFinalizedEvent {
                         account: account_addr,
@@ -883,7 +883,7 @@ module publisher::vip_vesting {
             vested_reward = vested_reward + value.vest_max_amount;
             value.remaining_reward = value.remaining_reward - value.vest_max_amount;
 
-            if (claim_info.start_stage >= value.end_stage) {
+            if (claim_info.start_stage == value.end_stage) {
                 event::emit(
                     OperatorVestingFinalizedEvent {
                         account: account_addr,

--- a/precompile/modules/initia_stdlib/sources/vip/vip.move
+++ b/precompile/modules/initia_stdlib/sources/vip/vip.move
@@ -145,8 +145,8 @@ module publisher::vip {
         operator_addr: address,
         vip_l2_score_contract: string::String,
         vip_weight: Decimal256,
-        operator_reward_store_addr: address,
-        user_reward_store_addr: address,
+        // operator_reward_store_addr: address,
+        // user_reward_store_addr: address,
     }
 
     struct ExecutedChallenge has store, drop {
@@ -201,8 +201,8 @@ module publisher::vip {
         operator_addr: address,
         vip_l2_score_contract: string::String,
         vip_weight: Decimal256,
-        user_reward_store_addr: address,
-        operator_reward_store_addr: address,
+        // user_reward_store_addr: address,
+        // operator_reward_store_addr: address,
     }
 
     struct ExecutedChallengeResponse has drop {
@@ -233,8 +233,8 @@ module publisher::vip {
     struct RewardDistributionEvent has drop, store {
         stage: u64,
         bridge_id: u64,
-        user_reward_store_addr: address,
-        operator_reward_store_addr: address,
+        // user_reward_store_addr: address,
+        // operator_reward_store_addr: address,
         user_reward_amount: u64,
         operator_reward_amount: u64
     }
@@ -628,8 +628,6 @@ module publisher::vip {
                 RewardDistributionEvent {
                     stage,
                     bridge_id,
-                    user_reward_store_addr: bridge.user_reward_store_addr,
-                    operator_reward_store_addr: bridge.operator_reward_store_addr,
                     user_reward_amount: fungible_asset::amount(&user_reward_sum),
                     operator_reward_amount: fungible_asset::amount(&commission_sum)
                 }
@@ -1001,12 +999,12 @@ module publisher::vip {
                 operator_commission_rate,
             );
         };
-        if (!vip_reward::is_operator_reward_store_registered(bridge_id)) {
-            vip_reward::register_operator_reward_store(chain, bridge_id);
-        };
-        if (!vip_reward::is_user_reward_store_registered(bridge_id)) {
-            vip_reward::register_user_reward_store(chain, bridge_id);
-        };
+        // if (!vip_reward::is_operator_reward_store_registered(bridge_id)) {
+        //     vip_reward::register_operator_reward_store(chain, bridge_id);
+        // };
+        // if (!vip_reward::is_user_reward_store_registered(bridge_id)) {
+        //     vip_reward::register_user_reward_store(chain, bridge_id);
+        // };
 
         // add bridge info
         table::add(
@@ -1018,8 +1016,6 @@ module publisher::vip {
                 operator_addr: operator,
                 vip_l2_score_contract,
                 vip_weight: decimal256::zero(),
-                user_reward_store_addr: vip_reward::get_user_reward_store_address(bridge_id),
-                operator_reward_store_addr: vip_reward::get_operator_reward_store_address(bridge_id),
             },
         );
     }
@@ -1860,8 +1856,6 @@ module publisher::vip {
             operator_addr: bridge.operator_addr,
             vip_l2_score_contract: bridge.vip_l2_score_contract,
             vip_weight: bridge.vip_weight,
-            user_reward_store_addr: bridge.user_reward_store_addr,
-            operator_reward_store_addr: bridge.operator_reward_store_addr,
         }
     }
 
@@ -1903,8 +1897,6 @@ module publisher::vip {
                     operator_addr: bridge.operator_addr,
                     vip_l2_score_contract: bridge.vip_l2_score_contract,
                     vip_weight: bridge.vip_weight,
-                    user_reward_store_addr: bridge.user_reward_store_addr,
-                    operator_reward_store_addr: bridge.operator_reward_store_addr,
                 }
             );
         };
@@ -4429,17 +4421,6 @@ module publisher::vip {
             bridge_id
         );
         let bridge_info = get_bridge_info(bridge_id);
-        assert!(
-            bridge_info.user_reward_store_addr == user_reward_store_addr && bridge_info.operator_reward_store_addr ==
-                 operator_reward_store_addr && bridge_info.operator_addr == operator_addr
-                && bridge_info.bridge_addr == @0x99 && decimal256::is_same(
-                &bridge_info.vip_weight,
-                &decimal256::from_string(
-                    &string::utf8(DEFAULT_VIP_WEIGHT_RATIO_FOR_TEST)
-                )
-            ),
-            7
-        );
         assert!(
             vip_reward::get_stage_reward(user_reward_store_addr, 1) == total_reward_per_stage,
             8

--- a/precompile/modules/initia_stdlib/sources/vip/vip_test.move
+++ b/precompile/modules/initia_stdlib/sources/vip/vip_test.move
@@ -529,7 +529,7 @@ module publisher::vip_test {
             merkle_proofs,
             l2_scores
         );
-        let (stages, merkle_proofs, l2_scores) = reset_claim_args();
+        (stages, merkle_proofs, l2_scores) = reset_claim_args();
         submit_snapshot_and_fund_reward(
             publisher,
             user_addr,
@@ -558,231 +558,6 @@ module publisher::vip_test {
             1000,
             usdc_metadata()
         );
-    }
-
-    #[test(chain = @initia_std, publisher = @publisher, operator = @0x2, user = @0x3)]
-    fun claim_amount_test(
-        chain: &signer,
-        publisher: &signer,
-        operator: &signer,
-        user: &signer
-    ) acquires TestState {
-        initialize(chain, publisher, operator);
-        let user_addr = signer::address_of(user);
-        coin::transfer(
-            chain,
-            user_addr,
-            usdc_metadata(),
-            1000000
-        );
-        let (stages, merkle_proofs, l2_scores) = reset_claim_args();
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 1 min score: 100, 75%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 2 min score: 50, 100%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 3 min score: 100, 75%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 4 min score: 50, 100%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 5 min score: 100, 75%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 6 min score: 50, 100%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 7 min score: 100, 75%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 8 min score: 50, 100%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 9 min score: 100, 75%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 10 min score: 50, 100%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 11 min score: 100, 65%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 12 min score: 50, 80%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 13 min score: 100, 50%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 14 min score: 50, 60%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 15 min score: 100, 35%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 16 min score: 100, 40%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            100,
-            200,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 17 min score: 100, 20%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            user_addr,
-            50,
-            100,
-            &mut stages,
-            &mut merkle_proofs,
-            &mut l2_scores
-        ); // stage 18 min score: 100, 20%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            @0x1,
-            0,
-            0,
-            &mut stages,
-            &mut vector[],
-            &mut vector[]
-        ); // stage 19 min score: 100, 5%
-        submit_snapshot_and_fund_reward(
-            publisher,
-            @0x1,
-            0,
-            0,
-            &mut stages,
-            &mut vector[],
-            &mut vector[]
-        ); // stage 20 min score: 100, 0%
-        vector::push_back(&mut merkle_proofs, vector[]);
-        vector::push_back(&mut l2_scores, 0);
-        vector::push_back(&mut merkle_proofs, vector[]);
-        vector::push_back(&mut l2_scores, 0);
-        // total sum = 1250%
-        // calculation
-        // reward per stage: 10_000
-        // maximum tvl ratio: 100%
-        // vesting period: 10
-        // operator commission: 50%
-        // pool split ratio: 50%
-        // user reward per each stage: 2_500
-        // user(@0x3) reward per each stage: 1_250
-        // reward amount per each stage (05 penalty): 125
-        // reward amount per each stage (50% penalty): 63 (round down for penalty)
-        let init_balance_before = coin::balance(user_addr, init_metadata());
-        vip::batch_claim_user_reward_script(
-            user,
-            get_bridge_id(),
-            stages,
-            merkle_proofs,
-            l2_scores
-        );
-        let init_balance_after = coin::balance(user_addr, init_metadata());
-        vip::zapping_script(user, get_bridge_id(), get_lp_metadata(), option::none(), get_validator(), 18, 1000, 1000, usdc_metadata());
-        // std::debug::print(&(1250 * get_reward_per_stage() / 2  / 2 / 2 / 100));
-        assert!(init_balance_after - init_balance_before == 12 * get_reward_per_stage() / 2 / 2, 0);
     }
 
     #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
@@ -946,546 +721,542 @@ module publisher::vip_test {
         let vesting1_initial_reward = vip_vesting::get_user_vesting_initial_reward(
             receiver_addr, get_bridge_id(), 1
         );
-        let vault_balance_after = vip_reward::balance(receiver_addr);
-        // vested stage 1 reward((stage_reward  + vested stage 2 reward(0)
+        let vault_balance_after = vip_vault::balance();
+        // vested stage 1 reward(stage_reward  + vested stage 2 reward(0))
         assert!(
             vip_reward::balance(receiver_addr) == (
                 vesting1_initial_reward / vesting_period
             ),
             9
         );
-        // claim with no reward and full penalty of vesting2 position
-        // vault balance reduce only amount of claim reward
+        // claim no reward of vesting2 position; vault balance reduce only amount of claim reward
         assert!(
-            vault_balance_after == vault_balance_before - vesting1_initial_reward / vesting_period,
+            vault_balance_after == vault_balance_before -  vip_reward::balance(receiver_addr),
             10
         )
 
     }
 
-    // #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
-    // fun claim_with_zero_total_score(
-    //     chain: &signer,
-    //     publisher: &signer,
-    //     operator: &signer,
-    //     receiver: &signer,
-    // ) {
-    //     initialize(chain, publisher, operator);
-    //     let receiver_addr = signer::address_of(receiver);
-    //     let vesting_period = get_vesting_period();
-    //     // stage 1 fund
-    //     vip::fund_reward_script(publisher); // 0->1
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     //stage 2 fund
-    //     vip::fund_reward_script(publisher); // 1->2
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     // submit snapshot of stage 1; total score: 1000, receiver's score : 100
-    //     let (
-    //         stage1_merkle_root,
-    //         stage1_merkle_proof
-    //     ) = get_merkle_root_and_proof(1, receiver_addr, 100, 1000);
-    //     // stage 1 snapshot submitted
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         1,
-    //         1,
-    //         stage1_merkle_root,
-    //         1000
-    //     );
-    //     skip_period(TEST_CHALLENGE_PERIOD + 1);
-    //     // stage 1 claimed; vesting position created
-    //     vip::batch_claim_user_reward_script(
-    //         receiver,
-    //         1,
-    //         vector[1],
-    //         vector[stage1_merkle_proof],
-    //         vector[100],
-    //     );
-    //     // stage 3 fund
-    //     vip::fund_reward_script(publisher); // 2 -> 3
+    #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
+    fun claim_with_total_zero_score(
+        chain: &signer,
+        publisher: &signer,
+        operator: &signer,
+        receiver: &signer,
+    ) acquires TestState {
+        initialize(chain, publisher, operator);
+        let receiver_addr = signer::address_of(receiver);
+        let vesting_period = get_vesting_period();
+        let (stages, merkle_proofs, l2_scores) = reset_claim_args();
+        // submit snapshot of stage 1; total score: 1000, receiver's score : 100
+        // stage 1 snapshot submitted
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            100,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        // stage 2
+        // total score: 1000, receiver's score : 500
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            500,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        // stage 3
+        // total score: 0, receiver's score : 0
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            0,
+            0,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
 
-    //     assert!(
-    //         vip::get_last_submitted_stage(get_bridge_id()) == 1,
-    //         2
-    //     );
+        // stage 4
+        // total score: 1000, receiver's score : 100
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            100,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        assert!(
+            vip_reward::balance(receiver_addr) == 0,
+            1
+        );
 
-    //     assert!(
-    //         vip_reward::balance(receiver_addr) == 0,
-    //         1
-    //     );
+        let vault_balance_before = vip_vault::balance();
+        // stage 1, 2, 3, 4 claimed
+        vip::batch_claim_user_reward_script(
+            receiver,
+            get_bridge_id(),
+            stages,
+            merkle_proofs,
+            l2_scores
+        );
+        let vesting1_initial_reward = vip_vesting::get_user_vesting_initial_reward(
+            receiver_addr, get_bridge_id(), 1
+        );
+        let vesting2_initial_reward = vip_vesting::get_user_vesting_initial_reward(
+            receiver_addr, get_bridge_id(), 2
+        );
+        let vesting3_initial_reward = vip_vesting::get_user_vesting_initial_reward(
+            receiver_addr, get_bridge_id(), 3
+        ); 
+        assert!(vesting3_initial_reward == 0, 5);
+        let vesting1_net_reward = 2 * vesting1_initial_reward / vesting_period; // stage 2 : 100%, stage 3: 0% , stage 4 : 100%
+        let vesting2_net_reward = 2 * vesting2_initial_reward / (5 * vesting_period); // stage 3: 0%, stage 4 : 40%
+        let vault_balance_after = vip_vault::balance();
+        assert!(vip_reward::balance(receiver_addr) == vesting1_net_reward + vesting2_net_reward, 6);
+        assert!(vault_balance_after == vault_balance_before - vip_reward::balance(receiver_addr),7);
+        
+    }
 
-    //     assert!(
-    //         vip_vesting::get_user_last_claimed_stage(receiver_addr, 1) == 1,
-    //         3
-    //     );
-    //     let vesting1_initial_reward = vip_vesting::get_user_vesting_initial_reward(
-    //         receiver_addr, get_bridge_id(), 1
-    //     );
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     // stage 2
-    //     // total score: 1000, receiver's score : 500
-    //     let (
-    //         stage2_merkle_root,
-    //         stage2_merkle_proof
-    //     ) = get_merkle_root_and_proof(2, receiver_addr, 500, 1000);
+    #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
+    fun zapping_vesting_position(
+        chain: &signer,
+        publisher: &signer,
+        operator: &signer,
+        receiver: &signer,
+    ) acquires TestState {
+        let receiver_addr = signer::address_of(receiver);
+        initialize(chain, publisher, operator);
+        coin::transfer(
+            chain,
+            receiver_addr,
+            usdc_metadata(),
+            1_000_000
+        );
+        let (stages, merkle_proofs, l2_scores) = reset_claim_args();
+        // submit snapshot of stage 1; total score: 1000, receiver's score : 100
+        // stage 1 snapshot submitted
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            100,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        assert!(
+            vip::get_last_submitted_stage(1) == 1,
+            2
+        );
+        // stage 2
+        // total score: 1000, receiver's score : 500
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            500,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        assert!(
+            vip_reward::balance(receiver_addr) == 0,
+            3
+        );
 
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         get_bridge_id(),
-    //         2,
-    //         stage2_merkle_root,
-    //         1000
-    //     );
-    //     skip_period(TEST_CHALLENGE_PERIOD + 1);
-    //     vip::batch_claim_user_reward_script(
-    //         receiver,
-    //         1,
-    //         vector[2],
-    //         vector[stage2_merkle_proof],
-    //         vector[500],
-    //     );
-    //     let vesting2_initial_reward = vip_vesting::get_user_vesting_initial_reward(
-    //         receiver_addr, get_bridge_id(), 2
-    //     );
-    //     // check vested stage 1 reward claimed; no missed INIT
+        vip::batch_claim_user_reward_script(
+            receiver,
+            get_bridge_id(),
+            stages,
+            merkle_proofs,
+            l2_scores
+        );
 
-    //     assert!(
-    //         vip_reward::balance(receiver_addr) == (
-    //             vesting1_initial_reward / vesting_period
-    //         ),
-    //         4
-    //     );
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     // stage 4 funded
-    //     vip::fund_reward_script(publisher); // 3 -> 4
-    //     let vault_balance = vip_vault::balance();
-    //     // stage 3
-    //     // total score: 0, receiver's score : 0
-    //     let (
-    //         stage3_merkle_root,
-    //         stage3_merkle_proof
-    //     ) = get_merkle_root_and_proof(3, receiver_addr, 0, 0);
+        let remaining_reward = vip_vesting::get_user_vesting_remaining(
+            receiver_addr, get_bridge_id(), 1
+        );
+        // zapping stage 1 vesting position; remaining reward: (stage_reward) * 100 / 1000
+        // without waiting the challenge period
+        vip::zapping_script(
+            receiver,
+            1,
+            get_lp_metadata(),
+            option::none(),
+            get_validator(),
+            1,
+            remaining_reward,
+            1_000_000,
+            usdc_metadata()
+        );
+        assert!(
+            vip_vesting::get_user_vesting_remaining(receiver_addr, get_bridge_id(), 1) ==
+                0,
+            5
+        );
 
-    //     // stage 3 snapshot submitted
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         get_bridge_id(),
-    //         3,
-    //         stage3_merkle_root,
-    //         0
-    //     );
-    //     skip_period(TEST_CHALLENGE_PERIOD + 1);
-    //     // stage 3 claim
-    //     vip::batch_claim_user_reward_script(
-    //         receiver,
-    //         1,
-    //         vector[3],
-    //         vector[stage3_merkle_proof],
-    //         vector[0],
-    //     );
+    }
 
-    //     // add on claimed vesting positions and finalized vesting positions
-    //     assert!(
-    //         vip_vesting::get_user_last_claimed_stage(receiver_addr, 1) == 3,
-    //         5
-    //     );
-    //     assert!(
-    //         vip_vesting::get_user_vesting_initial_reward(receiver_addr, 1, 3) == 0,
-    //         6
-    //     );
-    //     assert!(
-    //         vip_vesting::get_user_vesting_remaining(receiver_addr, 1, 3) == 0,
-    //         7
-    //     );
+    #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
+    fun zapping_vesting_position_in_challenge_period(
+        chain: &signer,
+        publisher: &signer,
+        operator: &signer,
+        receiver: &signer,
+    ) acquires TestState {
+        let receiver_addr = signer::address_of(receiver);
+        initialize(chain, publisher, operator);
+        coin::transfer(
+            chain,
+            receiver_addr,
+            usdc_metadata(),
+            1_000_000
+        );
+        let (stages, merkle_proofs, l2_scores) = reset_claim_args();
+        // submit snapshot of stage 1; total score: 1000, receiver's score : 100
+        // stage 1 snapshot submitted
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            100,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        // create stage 1 vesting position
+        vip::batch_claim_user_reward_script(
+            receiver,
+            get_bridge_id(),
+            stages,
+            merkle_proofs,
+            l2_scores
+        );
 
-    //     // vested stage 1 reward((stage_reward  + vested stage 2 reward(0)
-    //     assert!(
-    //         vip_reward::balance(receiver_addr) == (
-    //             vesting1_initial_reward / vesting_period
-    //         ),
-    //         8
-    //     );
-    //     // claim with no reward and full penalty of vesting position of stage 2
-    //     assert!(
-    //         vip_vault::balance() == vault_balance + (
-    //             vesting1_initial_reward / vesting_period
-    //         ) + (
-    //             vesting2_initial_reward / vesting_period
-    //         ),
-    //         9
-    //     )
+        // submit snapshot of stage 2; total score: 1000, receiver's score : 100
+        // stage 2 snapshot submitted
+        vip::fund_reward_script(publisher);
+        let test_state = borrow_global_mut<TestState>(@publisher);
+        test_state.last_submitted_stage = test_state.last_submitted_stage + 1;
+        let stage = test_state.last_submitted_stage;
+        let (merkle_root, _) = get_merkle_root_and_proof(
+            stage, receiver_addr, 100, 1000
+        );
+        vip::submit_snapshot(
+            publisher,
+            get_bridge_id(),
+            stage,
+            merkle_root,
+            1000
+        );
+        assert!(
+            vip::get_last_submitted_stage(1) == 2,
+            2
+        );
 
-    // }
+        
+        let remaining_reward = vip_vesting::get_user_vesting_remaining(
+            receiver_addr, get_bridge_id(), 1
+        );
+        // zapping stage 1 vesting position; remaining reward: (stage_reward) * 100 / 1000
+        // without waiting the challenge period of vesting position2
+        vip::zapping_script(
+            receiver,
+            1,
+            get_lp_metadata(),
+            option::none(),
+            get_validator(),
+            1,
+            remaining_reward,
+            1_000_000,
+            usdc_metadata()
+        );
+        assert!(
+            vip_vesting::get_user_vesting_remaining(receiver_addr, get_bridge_id(), 1) ==
+                0,
+            5
+        );
 
-    // #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
-    // fun zapping_vesting_position(
-    //     chain: &signer,
-    //     publisher: &signer,
-    //     operator: &signer,
-    //     receiver: &signer,
-    // ) {
-    //     let receiver_addr = signer::address_of(receiver);
-    //     initialize(chain, publisher, operator);
-    //     coin::transfer(
-    //         chain,
-    //         receiver_addr,
-    //         usdc_metadata(),
-    //         1_000_000
-    //     );
-    //     // stage 1
-    //     vip::fund_reward_script(publisher);
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     // stage 2
-    //     vip::fund_reward_script(publisher);
-    //     // stage 1 total score: 1000, receiver's score : 100
-    //     let (
-    //         stage1_merkle_root,
-    //         stage1_merkle_proof
-    //     ) = get_merkle_root_and_proof(1, receiver_addr, 100, 1000);
-    //     // stage 1 snapshot submitted
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         get_bridge_id(),
-    //         1,
-    //         stage1_merkle_root,
-    //         1000
-    //     );
-    //     skip_period(TEST_CHALLENGE_PERIOD + 1);
-    //     assert!(
-    //         vip::get_last_submitted_stage(1) == 1,
-    //         2
-    //     );
-    //     assert!(
-    //         vip_reward::balance(receiver_addr) == 0,
-    //         3
-    //     );
-    //     // stage 1 vesting position created
-    //     vip::batch_claim_user_reward_script(
-    //         receiver,
-    //         get_bridge_id(),
-    //         vector[1],
-    //         vector[stage1_merkle_proof],
-    //         vector[100],
-    //     );
-    //     assert!(
-    //         vip_vesting::get_user_last_claimed_stage(receiver_addr, 1) == 1,
-    //         4
-    //     );
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     vip::fund_reward_script(publisher);
-    //     let (
-    //         stage2_merkle_root,
-    //         stage2_merkle_proof
-    //     ) = get_merkle_root_and_proof(2, receiver_addr, 100, 1000);
+    }
 
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         1,
-    //         2,
-    //         stage2_merkle_root,
-    //         1000
-    //     );
-    //     skip_period(TEST_CHALLENGE_PERIOD + 1);
-    //     // stage 2
-    //     vip::batch_claim_user_reward_script(
-    //         receiver,
-    //         get_bridge_id(),
-    //         vector[2],
-    //         vector[stage2_merkle_proof],
-    //         vector[100],
-    //     );
-    //     let remaining_reward = vip_vesting::get_user_vesting_remaining(
-    //         receiver_addr, get_bridge_id(), 1
-    //     );
-    //     // zapping stage 1 vesting position; remaining reward: (stage_reward) * 100 / 1000
-    //     // without waiting the challenge period
-    //     vip::zapping_script(
-    //         receiver,
-    //         1,
-    //         get_lp_metadata(),
-    //         option::none(),
-    //         get_validator(),
-    //         1,
-    //         remaining_reward,
-    //         1_000_000,
-    //         usdc_metadata()
-    //     );
-    //     assert!(
-    //         vip_vesting::get_user_vesting_remaining(receiver_addr, get_bridge_id(), 1) ==
-    //             0,
-    //         5
-    //     );
+    #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
+    #[expected_failure(abort_code = 0xC0014, location = vip)]
+    fun failed_zapping_vesting_position_without_claim(
+        chain: &signer,
+        publisher: &signer,
+        operator: &signer,
+        receiver: &signer,
+    ) acquires TestState {
+        let receiver_addr = signer::address_of(receiver);
+        initialize(chain, publisher, operator);
+        coin::transfer(
+            chain,
+            receiver_addr,
+            usdc_metadata(),
+            1_000_000
+        );
+        let (stages, merkle_proofs, l2_scores) = reset_claim_args();
+        // submit snapshot of stage 1; total score: 1000, receiver's score : 100
+        // stage 1 snapshot submitted
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            100,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        // create stage 1 vesting position
+        vip::batch_claim_user_reward_script(
+            receiver,
+            get_bridge_id(),
+            stages,
+            merkle_proofs,
+            l2_scores
+        );
 
-    // }
+        assert!(
+            vip::get_last_submitted_stage(1) == 1,
+            2
+        );
+        // stage 2
+        // total score: 1000, receiver's score : 500
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            500,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        assert!(
+            vip_reward::balance(receiver_addr) == 0,
+            3
+        );
+        let remaining_reward = vip_vesting::get_user_vesting_remaining(
+            receiver_addr, get_bridge_id(), 1
+        );
+        // zapping stage 1 vesting position; remaining reward: (stage_reward) * 100 / 1000
+        // without waiting the challenge period
+        vip::zapping_script(
+            receiver,
+            1,
+            get_lp_metadata(),
+            option::none(),
+            get_validator(),
+            1,
+            remaining_reward,
+            1_000_000,
+            usdc_metadata()
+        )
+    }
 
-    // #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
-    // fun zapping_vesting_position_in_challenge_period(
-    //     chain: &signer,
-    //     publisher: &signer,
-    //     operator: &signer,
-    //     receiver: &signer,
-    // ) {
-    //     let receiver_addr = signer::address_of(receiver);
-    //     initialize(chain, publisher, operator);
-    //     coin::transfer(
-    //         chain,
-    //         receiver_addr,
-    //         usdc_metadata(),
-    //         1_000_000
-    //     );
-    //     // stage 1
-    //     vip::fund_reward_script(publisher);
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     // stage 2
-    //     vip::fund_reward_script(publisher);
-    //     // stage 1 total score: 1000, receiver's score : 100
-    //     let (
-    //         stage1_merkle_root,
-    //         stage1_merkle_proof
-    //     ) = get_merkle_root_and_proof(1, receiver_addr, 100, 1000);
-    //     // stage 1 snapshot submitted
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         get_bridge_id(),
-    //         1,
-    //         stage1_merkle_root,
-    //         1000
-    //     );
-    //     skip_period(TEST_CHALLENGE_PERIOD + 1);
-    //     assert!(
-    //         vip::get_last_submitted_stage(1) == 1,
-    //         2
-    //     );
-    //     assert!(
-    //         vip_reward::balance(receiver_addr) == 0,
-    //         3
-    //     );
-    //     // stage 1 vesting position created
-    //     vip::batch_claim_user_reward_script(
-    //         receiver,
-    //         get_bridge_id(),
-    //         vector[1],
-    //         vector[stage1_merkle_proof],
-    //         vector[100],
-    //     );
-    //     assert!(
-    //         vip_vesting::get_user_last_claimed_stage(receiver_addr, 1) == 1,
-    //         4
-    //     );
-    //     let initial_reward = vip_vesting::get_user_vesting_initial_reward(
-    //         receiver_addr, get_bridge_id(), 1
-    //     );
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     vip::fund_reward_script(publisher);
-    //     let (stage2_merkle_root, _) = get_merkle_root_and_proof(1, receiver_addr, 100,
-    //             1000);
+    #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
+    #[expected_failure(abort_code = 0xD001f, location = vip)]
+    fun fail_submit_snapshot_and_fund_reward_with_deregistered_bridge(
+        chain: &signer,
+        publisher: &signer,
+        operator: &signer,
+    ) {
+        initialize(chain, publisher, operator);
+        vip::fund_reward_script(publisher); // stage 1 distributed
+        skip_period(TEST_STAGE_INTERVAL + 1);
+        vip::fund_reward_script(publisher); // stage 2 distributed
+        vip::deregister(publisher, get_bridge_id()); // TODO: should change publisher -> chain
 
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         1,
-    //         2,
-    //         stage2_merkle_root,
-    //         1000
-    //     );
-    //     // zapping stage 1 vesting position; remaining reward: (stage_reward) * 100 / 1000
-    //     // without waiting the challenge period
-    //     vip::zapping_script(
-    //         receiver,
-    //         1,
-    //         get_lp_metadata(),
-    //         option::none(),
-    //         get_validator(),
-    //         1,
-    //         initial_reward,
-    //         1_000_000,
-    //         usdc_metadata()
-    //     );
-    //     assert!(
-    //         vip_vesting::is_user_vesting_position_finalized(receiver_addr, 1, 1),
-    //         5
-    //     );
+        let (stage1_merkle_root, _) = get_merkle_root_and_proof(
+            1,
+            signer::address_of(publisher),
+            100,
+            1000
+        );
+        vip::submit_snapshot(// stage 1 snapshot submitted; but fail because the corresponding bridge is deregistered
+            publisher,
+            get_bridge_id(),
+            1,
+            stage1_merkle_root,
+            1000
+        );
+    }
 
-    //     assert!(
-    //         vip_vesting::get_user_vesting_remaining(receiver_addr, get_bridge_id(), 1) ==
-    //             0,
-    //         6
-    //     );
-    // }
+    #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
+    fun zapping_deregistered_bridge_vesting_positions(
+        chain: &signer,
+        publisher: &signer,
+        operator: &signer,
+        receiver: &signer,
+    ) acquires TestState {
+        initialize(chain, publisher, operator);
+        let receiver_addr = signer::address_of(receiver);
+        coin::transfer(
+            chain,
+            receiver_addr,
+            usdc_metadata(),
+            1_000_000
+        );
+        let (stages, merkle_proofs, l2_scores) = reset_claim_args();
 
-    // #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
-    // #[expected_failure(abort_code = 0xC0014, location = vip)]
-    // fun failed_zapping_vesting_position_without_claim(
-    //     chain: &signer,
-    //     publisher: &signer,
-    //     operator: &signer,
-    //     receiver: &signer,
-    // ) {
-    //     let receiver_addr = signer::address_of(receiver);
-    //     initialize(chain, publisher, operator);
-    //     coin::transfer(
-    //         chain,
-    //         receiver_addr,
-    //         usdc_metadata(),
-    //         1_000_000
-    //     );
-    //     // stage 1
-    //     vip::fund_reward_script(publisher);
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     // stage 2
-    //     vip::fund_reward_script(publisher);
-    //     // stage 1 total score: 1000, receiver's score : 100
-    //     let (
-    //         stage1_merkle_root,
-    //         stage1_merkle_proof
-    //     ) = get_merkle_root_and_proof(1, receiver_addr, 100, 1000);
-    //     // stage 1 snapshot submitted
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         get_bridge_id(),
-    //         1,
-    //         stage1_merkle_root,
-    //         1000
-    //     );
-    //     skip_period(TEST_CHALLENGE_PERIOD + 1);
-    //     assert!(
-    //         vip::get_last_submitted_stage(1) == 1,
-    //         2
-    //     );
-    //     assert!(
-    //         vip_reward::balance(receiver_addr) == 0,
-    //         3
-    //     );
-    //     // stage 1 vesting position created
-    //     vip::batch_claim_user_reward_script(
-    //         receiver,
-    //         get_bridge_id(),
-    //         vector[1],
-    //         vector[stage1_merkle_proof],
-    //         vector[100],
-    //     );
-    //     assert!(
-    //         vip_vesting::get_user_last_claimed_stage(receiver_addr, 1) == 1,
-    //         4
-    //     );
-    //     let remaining_reward = vip_vesting::get_user_vesting_remaining(
-    //         receiver_addr, get_bridge_id(), 1
-    //     );
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     vip::fund_reward_script(publisher);
-    //     let (stage2_merkle_root, _) = get_merkle_root_and_proof(2, receiver_addr, 100,
-    //             1000);
+        // submit snapshot of stage 1; total score: 1000, receiver's score : 100
+        // stage 1 snapshot submitted
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            100,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        
+        
+        // minitia submits the snapshot but deregistered by gov. 
+        vip::deregister(publisher, get_bridge_id());
+        
+        // create user reward position of stage 1
+        vip::batch_claim_user_reward_script(
+            receiver,
+            get_bridge_id(),
+            stages,
+            merkle_proofs,
+            l2_scores,
+        );
 
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         1,
-    //         2,
-    //         stage2_merkle_root,
-    //         1000
-    //     );
-    //     skip_period(TEST_CHALLENGE_PERIOD + 1);
-    //     // zapping stage 1 vesting position; remaining reward: (stage_reward) * 100 / 1000
-    //     // without waiting the challenge period
-    //     vip::zapping_script(
-    //         receiver,
-    //         1,
-    //         get_lp_metadata(),
-    //         option::none(),
-    //         get_validator(),
-    //         1,
-    //         remaining_reward,
-    //         1_000_000,
-    //         usdc_metadata()
-    //     )
-    // }
+        let initial_reward = vip_vesting::get_user_vesting_initial_reward(
+            signer::address_of(receiver),
+            get_bridge_id(),
+            1
+        );
+        // user can only zap the deregisterd minitia positions 
+        vip::zapping_script(
+            receiver,
+            get_bridge_id(),
+            get_lp_metadata(),
+            option::none(),
+            get_validator(),
+            1,
+            initial_reward,
+            1000_000,
+            usdc_metadata()
+        )
+    }
 
-    // #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
-    // #[expected_failure(abort_code = 0x6000e, location = vip)]
-    // fun block_submit_snapshot_and_fund_reward_with_deregistered_bridge(
-    //     chain: &signer,
-    //     publisher: &signer,
-    //     operator: &signer,
-    // ) {
-    //     initialize(chain, publisher, operator);
-    //     vip::fund_reward_script(publisher); // stage 1 distributed
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     vip::fund_reward_script(publisher); // stage 2 distributed
-    //     vip::deregister(publisher, get_bridge_id()); // TODO: should change publisher -> chain
+     #[test(chain = @0x1, publisher = @publisher, operator = @0x56ccf33c45b99546cd1da172cf6849395bbf8573, receiver = @0x19c9b6007d21a996737ea527f46b160b0a057c37)]
+    fun test_batch_zapping(
+        chain: &signer,
+        publisher: &signer,
+        operator: &signer,
+        receiver: &signer
+    ) acquires TestState {
+        initialize(chain, publisher, operator);
+        let receiver_addr = signer::address_of(receiver);
+        coin::transfer(
+            chain,
+            receiver_addr,
+            usdc_metadata(),
+            1_000_000_000
+        );
+        let (stages, merkle_proofs, l2_scores) = reset_claim_args();
+        // submit snapshot of stage 1; total score: 1000, receiver's score : 100
+        // stage 1 snapshot submitted
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            100,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        // stage 2
+        // total score: 1000, receiver's score : 500
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            500,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
+        // stage 3
+        // total score: 1000, receiver's score : 200
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            200,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        );
 
-    //     let (stage1_merkle_root, _) = get_merkle_root_and_proof(
-    //         1,
-    //         signer::address_of(publisher),
-    //         100,
-    //         1000
-    //     );
-    //     vip::submit_snapshot_and_fund_reward(// stage 1 snapshot submitted
-    //         publisher,
-    //         get_bridge_id(),
-    //         1,
-    //         stage1_merkle_root,
-    //         1000
-    //     );
-    // }
+        // stage 4
+        // total score: 1000, receiver's score : 100
+        submit_snapshot_and_fund_reward(
+            publisher,
+            receiver_addr,
+            100,
+            1000,
+            &mut stages,
+            &mut merkle_proofs,
+            &mut l2_scores
+        ); 
+        // claim stage 1,2,3,4
+        vip::batch_claim_user_reward_script(
+            receiver,
+            get_bridge_id(),
+            stages,
+            merkle_proofs,
+            l2_scores
+        );
+        let stage = 1;
+        let zapping_amounts = vector::empty<u64>();
+        let stakelisted_amounts = vector::empty<u64>();
+        let min_liquidity = vector::empty<option::Option<u64>>();
+        let validators = vector::empty<string::String>();
+        let lp_metadatas = vector::empty<Object<Metadata>>();
+        let stakelist_metadatas = vector::empty<Object<Metadata>>();
+        while(stage < 5) {
+            
+            let remaining = vip_vesting::get_user_vesting_remaining(receiver_addr, get_bridge_id(), stage);
+            vector::push_back(&mut zapping_amounts, remaining);
+            vector::push_back(&mut stakelisted_amounts,remaining);
+            vector::push_back(&mut min_liquidity,option::none());
+            vector::push_back(&mut validators, get_validator());
+            vector::push_back(&mut lp_metadatas, get_lp_metadata());
+            vector::push_back(&mut stakelist_metadatas, usdc_metadata());
+            stage = stage + 1;
+        };
 
-    // fun zapping_deregistered_bridge_vesting_positions(
-    //     chain: &signer,
-    //     publisher: &signer,
-    //     operator: &signer,
-    //     receiver: &signer,
-    // ) {
-    //     initialize(chain, publisher, operator);
-    //     vip::fund_reward_script(publisher);
-    //     skip_period(TEST_STAGE_INTERVAL + 1);
-    //     vip::fund_reward_script(publisher);
-
-    //     let (
-    //         stage1_merkle_root,
-    //         stage1_merkle_proof
-    //     ) = get_merkle_root_and_proof(
-    //         1,
-    //         signer::address_of(publisher),
-    //         100,
-    //         1000
-    //     );
-    //     vip::submit_snapshot_and_fund_reward(
-    //         publisher,
-    //         get_bridge_id(),
-    //         1,
-    //         stage1_merkle_root,
-    //         1000
-    //     );
-    //     vip::deregister(publisher, get_bridge_id());
-
-    //     // create user reward position of stage 1
-    //     vip::batch_claim_user_reward_script(
-    //         receiver,
-    //         get_bridge_id(),
-    //         vector[1],
-    //         vector[stage1_merkle_proof],
-    //         vector[100],
-    //     );
-    //     let initial_reward = vip_vesting::get_user_vesting_initial_reward(
-    //         signer::address_of(receiver),
-    //         get_bridge_id(),
-    //         1
-    //     );
-
-    //     vip::zapping_script(
-    //         receiver,
-    //         get_bridge_id(),
-    //         get_lp_metadata(),
-    //         option::none(),
-    //         get_validator(),
-    //         1,
-    //         initial_reward,
-    //         1000_000,
-    //         usdc_metadata()
-    //     )
-    // }
-
-    // fun test_batch_zapping(){
-    // }
+        vip::batch_zapping_script(
+            receiver,
+            get_bridge_id(),
+            lp_metadatas,
+            min_liquidity,
+            validators,
+            stages,
+            zapping_amounts,
+            stakelisted_amounts,
+            stakelist_metadatas
+        );
 
 
-    // fun fail_zapping_full_vesting(){}
+        stage = 1;
+        while(stage < 5) {
+            assert!(vip_vesting::get_user_vesting_remaining(receiver_addr, get_bridge_id(), stage) == 0, 1);
+            stage = stage + 1;
+        };
+    }
+
+
 
 }

--- a/precompile/modules/initia_stdlib/sources/vip/vip_test.move
+++ b/precompile/modules/initia_stdlib/sources/vip/vip_test.move
@@ -1018,14 +1018,18 @@ module publisher::vip_test {
             5
         );
         assert!(
-            vip_vesting::get_user_vesting_finalized_initial_reward(receiver_addr, 1, 3
-            ) == 0,
+            vip_vesting::is_user_vesting_position_finalized(receiver_addr, 1, 3),
             6
         );
         assert!(
-            vip_vesting::get_user_vesting_finalized_remaining(receiver_addr, 1, 3) ==
-                0,
+            vip_vesting::get_user_vesting_initial_reward(receiver_addr, 1, 3) == 0,
             7
+        );
+        assert!(
+            vip_vesting::is_user_vesting_position_finalized(receiver_addr, 1, 3) && vip_vesting::get_user_vesting_remaining(
+                receiver_addr, 1, 3
+            ) == 0,
+            8
         );
 
         // vested stage 1 reward((stage_reward  + vested stage 2 reward(0)
@@ -1033,7 +1037,7 @@ module publisher::vip_test {
             vip_reward::balance(receiver_addr) == (
                 vesting1_initial_reward / vesting_period
             ),
-            8
+            9
         );
         // claim with no reward and full penalty of vesting2 position
         assert!(
@@ -1042,7 +1046,7 @@ module publisher::vip_test {
             ) + (
                 vesting2_initial_reward / vesting_period
             ),
-            9
+            10
         )
 
     }
@@ -1174,13 +1178,11 @@ module publisher::vip_test {
             5
         );
         assert!(
-            vip_vesting::get_user_vesting_finalized_initial_reward(receiver_addr, 1, 3
-            ) == 0,
+            vip_vesting::get_user_vesting_initial_reward(receiver_addr, 1, 3) == 0,
             6
         );
         assert!(
-            vip_vesting::get_user_vesting_finalized_remaining(receiver_addr, 1, 3) ==
-                0,
+            vip_vesting::get_user_vesting_remaining(receiver_addr, 1, 3) == 0,
             7
         );
 
@@ -1280,7 +1282,7 @@ module publisher::vip_test {
             vector[stage2_merkle_proof],
             vector[100],
         );
-        let remaining_reward = vip_vesting::get_user_vesting_remaining_reward(
+        let remaining_reward = vip_vesting::get_user_vesting_remaining(
             receiver_addr, get_bridge_id(), 1
         );
         // zapping stage 1 vesting position; remaining reward: (stage_reward) * 100 / 1000
@@ -1297,9 +1299,8 @@ module publisher::vip_test {
             usdc_metadata()
         );
         assert!(
-            vip_vesting::get_user_vesting_finalized_remaining(
-                receiver_addr, get_bridge_id(), 1
-            ) == 0,
+            vip_vesting::get_user_vesting_remaining(receiver_addr, get_bridge_id(), 1) ==
+                0,
             5
         );
 
@@ -1387,12 +1388,15 @@ module publisher::vip_test {
             1_000_000,
             usdc_metadata()
         );
+        assert!(
+            vip_vesting::is_user_vesting_position_finalized(receiver_addr, 1, 3),
+            5
+        );
 
         assert!(
-            vip_vesting::get_user_vesting_finalized_remaining(
-                receiver_addr, get_bridge_id(), 1
-            ) == 0,
-            5
+            vip_vesting::get_user_vesting_remaining(receiver_addr, get_bridge_id(), 1) ==
+                0,
+            6
         );
     }
 
@@ -1451,7 +1455,7 @@ module publisher::vip_test {
             vip_vesting::get_user_last_claimed_stage(receiver_addr, 1) == 1,
             4
         );
-        let remaining_reward = vip_vesting::get_user_vesting_remaining_reward(
+        let remaining_reward = vip_vesting::get_user_vesting_remaining(
             receiver_addr, get_bridge_id(), 1
         );
         skip_period(TEST_STAGE_INTERVAL + 1);

--- a/precompile/modules/initia_stdlib/sources/vip/weight_vote.move
+++ b/precompile/modules/initia_stdlib/sources/vip/weight_vote.move
@@ -41,7 +41,7 @@ module publisher::vip_weight_vote {
     const ECHALLENGE_IN_PROGRESS: u64 = 15;
     const ECHALLENGE_ALREADY_EXECUTED: u64 = 16;
     const EINVALID_PARAMETER: u64 = 17;
-    const EINVALID_BRIDGE:u64 = 18;
+    const EINVALID_BRIDGE: u64 = 18;
     //
     //  Constants
     //
@@ -409,7 +409,10 @@ module publisher::vip_weight_vote {
         vector::for_each(
             bridge_ids,
             |bridge_id| {
-                assert!(vip::is_registered(bridge_id),error::invalid_argument(EINVALID_BRIDGE));
+                assert!(
+                    vip::is_registered(bridge_id),
+                    error::invalid_argument(EINVALID_BRIDGE)
+                );
             }
         );
         let weight_sum = decimal128::new(0);
@@ -1239,20 +1242,21 @@ module publisher::vip_weight_vote {
         );
         let proposal = table::borrow(&module_store.proposals, cycle_key);
 
-        let tally_responses:vector<TallyResponse> = vector[];
+        let tally_responses: vector<TallyResponse> = vector[];
 
         let bridge_ids = vip::get_whitelisted_bridge_ids();
 
         vector::for_each(
             bridge_ids,
             |bridge_id| {
-                let tally = table::borrow_with_default(&proposal.tally, table_key::encode_u64(bridge_id), &0);
+                let tally = table::borrow_with_default(
+                    &proposal.tally,
+                    table_key::encode_u64(bridge_id),
+                    &0
+                );
                 vector::push_back(
                     &mut tally_responses,
-                    TallyResponse {
-                        bridge_id,
-                        tally: *tally
-                    }
+                    TallyResponse {bridge_id, tally: *tally}
                 )
             }
         );
@@ -1381,12 +1385,13 @@ module publisher::vip_weight_vote {
 
     #[test_only]
     use initia_std::coin;
-
     #[test_only]
     use initia_std::string;
 
     #[test_only]
     use initia_std::block;
+    #[test_only]
+    use publisher::vip_operator;
     #[test_only]
     const DEFAULT_VIP_L2_CONTRACT_FOR_TEST: vector<u8> = (b"vip_l2_contract");
 
@@ -1421,6 +1426,7 @@ module publisher::vip_weight_vote {
             string::utf8(b""),
             string::utf8(b""),
         );
+        vip_operator::init_module_for_test(publisher);
         vip::init_module_for_test(publisher);
         vip::register(
             publisher,

--- a/precompile/modules/initia_stdlib/sources/vip/weight_vote.move
+++ b/precompile/modules/initia_stdlib/sources/vip/weight_vote.move
@@ -1426,7 +1426,6 @@ module publisher::vip_weight_vote {
             string::utf8(b""),
             string::utf8(b""),
         );
-        vip_operator::init_module_for_test(publisher);
         vip::init_module_for_test(publisher);
         vip::register(
             publisher,
@@ -1770,7 +1769,7 @@ module publisher::vip_weight_vote {
         vote_challenge(u1, 1, true);
 
         // after min_voting_period
-        skip_period(1);
+        skip_period(10);
 
         // execute challenge
         execute_challenge(1);
@@ -1810,7 +1809,7 @@ module publisher::vip_weight_vote {
         vote_challenge(u2, 2, true);
 
         // after min_voting_period
-        set_block_info(100, 252);
+        skip_period(10);
 
         // execute proposal
         execute_challenge(2);

--- a/precompile/modules/initia_stdlib/sources/vip/weight_vote.move
+++ b/precompile/modules/initia_stdlib/sources/vip/weight_vote.move
@@ -1391,8 +1391,6 @@ module publisher::vip_weight_vote {
     #[test_only]
     use initia_std::block;
     #[test_only]
-    use publisher::vip_operator;
-    #[test_only]
     const DEFAULT_VIP_L2_CONTRACT_FOR_TEST: vector<u8> = (b"vip_l2_contract");
 
     #[test_only]

--- a/precompile/modules/initia_stdlib/sources/vip/weight_vote.move
+++ b/precompile/modules/initia_stdlib/sources/vip/weight_vote.move
@@ -441,7 +441,7 @@ module publisher::vip_weight_vote {
 
         // remove former vote
         if (table::contains(&proposal.votes, addr)) {
-            let WeightVote {voting_power:_, weights} = table::remove(&mut proposal.votes, addr);
+            let WeightVote {voting_power: _, weights} = table::remove(&mut proposal.votes, addr);
             remove_vote(proposal, max_voting_power, weights);
         };
 
@@ -1638,7 +1638,7 @@ module publisher::vip_weight_vote {
                 decimal128::from_ratio(1, 5)
             ], // 32, 8 // user can vote with
         );
-        
+
         vote1 = get_tally(1, 1);
         vote2 = get_tally(1, 2);
         total_tally = get_total_tally(1);
@@ -1656,7 +1656,7 @@ module publisher::vip_weight_vote {
             vector[
                 decimal128::zero(),
                 decimal128::zero()
-            ], // 0, 0 
+            ], // 0, 0
         );
 
         vote1 = get_tally(1, 1);
@@ -1671,8 +1671,6 @@ module publisher::vip_weight_vote {
             vector::length(&weight_vote.weights) == 2,
             13
         );
-
-        
 
         skip_period(60);
         execute_proposal();


### PR DESCRIPTION
There was an issue where unnecessary object stores were created, causing assets to be unnecessarily tied up. In this PR, we addressed this issue and performed refactoring to improve code readability
