### PR TITLE
chores: add table warning comment "always call next after prepare"

### DIFF
--- a/precompile/modules/initia_stdlib/sources/table.move
+++ b/precompile/modules/initia_stdlib/sources/table.move
@@ -174,6 +174,12 @@ module initia_std::table {
         new_table_iter<K, V, Box<V>>(self, start_bytes, end_bytes, order)
     }
 
+    /// Prepares the next key-value pair from the iterator for reading.
+    /// Returns true if a next item exists, false if iteration is complete.
+    /// 
+    /// CONTRACT: After calling prepare() and getting true, the caller MUST call next() 
+    /// to consume the prepared item before doing any other operations on the table,
+    /// since values are borrowed internally and block access until consumed.
     public fun prepare<K: copy + drop, V>(self: &TableIter<K, V>): bool {
         prepare_box<K, V, Box<V>>(self)
     }

--- a/precompile/modules/minitia_stdlib/sources/table.move
+++ b/precompile/modules/minitia_stdlib/sources/table.move
@@ -174,6 +174,12 @@ module minitia_std::table {
         new_table_iter<K, V, Box<V>>(self, start_bytes, end_bytes, order)
     }
 
+    /// Prepares the next key-value pair from the iterator for reading.
+    /// Returns true if a next item exists, false if iteration is complete.
+    /// 
+    /// CONTRACT: After calling prepare() and getting true, the caller MUST call next() 
+    /// to consume the prepared item before doing any other operations on the table,
+    /// since values are borrowed internally and block access until consumed.
     public fun prepare<K: copy + drop, V>(self: &TableIter<K, V>): bool {
         prepare_box<K, V, Box<V>>(self)
     }


### PR DESCRIPTION
# Description

We found, if the prepared value is not consumed properly the caller cannot use table properly.

---

## Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] included the necessary unit and integration tests
- [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional prepare step for table iterators to prefetch the next entry and indicate availability, enabling smoother iteration and potential performance gains. After a successful prepare, the next item must be consumed before other operations.

- Documentation
  - Expanded iterator documentation to explain the prepare step, its return behavior, and the requirement to consume the prepared item with the next operation. Clarifies that overall iteration semantics remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->