### PR TITLE
refactor: extract handleFFIResult helper to reduce FFI boilerplate

### DIFF
--- a/api/exposed.go
+++ b/api/exposed.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/initia-labs/movevm/types"
 )
@@ -30,12 +29,10 @@ func ReadModuleInfo(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_read_module_info(&errmsg, compiledView)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
-		return types.AccountAddress{}, "", errorWithMessage(err, errmsg)
+	resBz, err := handleFFIResult(res, errmsg, err)
+	if err != nil {
+		return types.AccountAddress{}, "", err
 	}
-
-	resBz := copyAndDestroyUnmanagedVector(res)
 
 	var moduleInfo ModuleInfoResponse
 	err = json.Unmarshal(resBz, &moduleInfo)
@@ -73,12 +70,7 @@ func DecodeMoveResource(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_decode_move_resource(db, &errmsg, structTagView, resourceBytesView)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }
 
 // DecodeMoveValue decode move value bytes to move value
@@ -108,12 +100,7 @@ func DecodeMoveValue(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_decode_move_value(db, &errmsg, typeTagView, valueBytesView)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }
 
 // DecodeModuleBytes decode module bytes to MoveModule
@@ -129,12 +116,7 @@ func DecodeModuleBytes(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_decode_module_bytes(&errmsg, moduleBytesView)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }
 
 // DecodeScriptBytes decode script bytes to MoveFunction
@@ -150,12 +132,7 @@ func DecodeScriptBytes(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_decode_script_bytes(&errmsg, scriptBytesView)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }
 
 // ParseStructTag parse string to StructTag
@@ -174,12 +151,12 @@ func ParseStructTag(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_parse_struct_tag(&errmsg, structTagStrView)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
-		return types.StructTag{}, errorWithMessage(err, errmsg)
+	resBz, err := handleFFIResult(res, errmsg, err)
+	if err != nil {
+		return types.StructTag{}, err
 	}
 
-	return types.BcsDeserializeStructTag(copyAndDestroyUnmanagedVector(res))
+	return types.BcsDeserializeStructTag(resBz)
 }
 
 // StringifyStructTag parse string to StructTag
@@ -199,12 +176,12 @@ func StringifyStructTag(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_stringify_struct_tag(&errmsg, structTagView)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
-		return "", errorWithMessage(err, errmsg)
+	resBz, err := handleFFIResult(res, errmsg, err)
+	if err != nil {
+		return "", err
 	}
 
-	return string(copyAndDestroyUnmanagedVector(res)), nil
+	return string(resBz), nil
 }
 
 func SortModuleBundle(
@@ -226,12 +203,10 @@ func SortModuleBundle(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_sort_module_bundle(&errmsg, moduleBundleBzView)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
-		return nil, errorWithMessage(err, errmsg)
+	resBz, err := handleFFIResult(res, errmsg, err)
+	if err != nil {
+		return nil, err
 	}
-
-	resBz := copyAndDestroyUnmanagedVector(res)
 
 	sortedModuleBundle, err := types.BcsDeserializeModuleBundle(resBz)
 	if err != nil {

--- a/api/lib.go
+++ b/api/lib.go
@@ -45,5 +45,7 @@ func handleFFIResult(res C.libmovevm_UnmanagedVector, errmsg C.libmovevm_Unmanag
 			return nil, errorWithMessage(err, errmsg)
 		}
 	}
+	// destroy errmsg on success path to avoid leaks
+	copyAndDestroyUnmanagedVector(errmsg)
 	return copyAndDestroyUnmanagedVector(res), nil
 }

--- a/api/lib.go
+++ b/api/lib.go
@@ -37,10 +37,13 @@ func errorWithMessage(err error, b C.libmovevm_UnmanagedVector) error {
 // checking the errno, destroying the unmanaged result vector, and returning
 // the appropriate byte slice or error.
 func handleFFIResult(res C.libmovevm_UnmanagedVector, errmsg C.libmovevm_UnmanagedVector, err error) ([]byte, error) {
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// always destroy res to avoid leaks
-		copyAndDestroyUnmanagedVector(res)
-		return nil, errorWithMessage(err, errmsg)
+	if err != nil {
+		errno, ok := err.(syscall.Errno)
+		if !ok || errno != C.libmovevm_ErrnoValue_Success {
+			// always destroy res to avoid leaks
+			copyAndDestroyUnmanagedVector(res)
+			return nil, errorWithMessage(err, errmsg)
+		}
 	}
 	return copyAndDestroyUnmanagedVector(res), nil
 }

--- a/api/lib.go
+++ b/api/lib.go
@@ -6,6 +6,7 @@ import "C"
 
 import (
 	"fmt"
+	"syscall"
 )
 
 // Value types
@@ -30,4 +31,16 @@ func errorWithMessage(err error, b C.libmovevm_UnmanagedVector) error {
 		return err
 	}
 	return fmt.Errorf("%s", string(msg))
+}
+
+// handleFFIResult is a helper that handles the common epilogue of FFI calls:
+// checking the errno, destroying the unmanaged result vector, and returning
+// the appropriate byte slice or error.
+func handleFFIResult(res C.libmovevm_UnmanagedVector, errmsg C.libmovevm_UnmanagedVector, err error) ([]byte, error) {
+	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
+		// always destroy res to avoid leaks
+		copyAndDestroyUnmanagedVector(res)
+		return nil, errorWithMessage(err, errmsg)
+	}
+	return copyAndDestroyUnmanagedVector(res), nil
 }

--- a/api/vm.go
+++ b/api/vm.go
@@ -6,7 +6,6 @@ import "C"
 
 import (
 	"runtime"
-	"syscall"
 )
 
 type VM struct {
@@ -60,11 +59,7 @@ func Initialize(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_initialize(vm.ptr, db, _api, e, mb, ap, &errmsg)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }
 
 // ExecuteContract call ffi(`execute_contract`) to execute
@@ -96,11 +91,7 @@ func ExecuteContract(
 
 	errmsg := uninitializedUnmanagedVector()
 	res, err := C.libmovevm_execute_contract(vm.ptr, (*C.uint64_t)(gasBalance), db, _api, e, sendersView, msg, &errmsg)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }
 
 // ExecuteScript call ffi(`execute_script`) to execute
@@ -133,11 +124,7 @@ func ExecuteScript(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_execute_script(vm.ptr, (*C.uint64_t)(gasBalance), db, _api, e, sendersView, msg, &errmsg)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }
 
 // ExecuteViewFunction call ffi(`execute_view_function`) to get
@@ -168,12 +155,7 @@ func ExecuteViewFunction(
 	errmsg := uninitializedUnmanagedVector()
 
 	res, err := C.libmovevm_execute_view_function(vm.ptr, (*C.uint64_t)(gasBalance), db, _api, e, msg, &errmsg)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.                                                                            │                                 struct ByteSliceView checksum,
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }
 
 func ExecuteAuthenticate(
@@ -204,9 +186,5 @@ func ExecuteAuthenticate(
 
 	errmsg := uninitializedUnmanagedVector()
 	res, err := C.libmovevm_execute_authenticate(vm.ptr, (*C.uint64_t)(gasBalance), db, _api, e, senderView, msg, &errmsg)
-	if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
-		return nil, errorWithMessage(err, errmsg)
-	}
-
-	return copyAndDestroyUnmanagedVector(res), err
+	return handleFFIResult(res, errmsg, err)
 }


### PR DESCRIPTION
## Summary
- Extracts repeated FFI epilogue pattern (errno check + vector cleanup + error handling) into a single `handleFFIResult` helper in `api/lib.go`
- Updates all 13 FFI call sites across `api/vm.go` and `api/exposed.go`
- Fixes two latent bugs: success-errno returned as non-nil error, and result vector not freed on error path (memory leak)

## Details
Every FFI function repeated this pattern:
```go
if err != nil && err.(syscall.Errno) != C.libmovevm_ErrnoValue_Success {
    return nil, errorWithMessage(err, errmsg)
}
return copyAndDestroyUnmanagedVector(res), err
```

The new helper centralizes this with defensive comma-ok type assertion (per Codex review) and proper cleanup in both paths.

Net: **+39 insertions, -70 deletions**

## Test plan
- [ ] Verify CGO compilation passes
- [ ] Run existing tests to confirm no behavioral regression
- [ ] The helper is a pure refactor — same logic, fewer lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated FFI error and result handling into a single, unified flow.
  * Simplified multiple exported API functions to delegate error/result cleanup and byte-result extraction to the new shared logic, improving consistency and reducing duplicated cleanup paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->