### PR TITLE
fix: correct TypeTag error message and harden vector parsing

### DIFF
--- a/api/exposed.go
+++ b/api/exposed.go
@@ -282,7 +282,7 @@ func StringifyTypeTag(tt types.TypeTag) (string, error) {
 		return StringifyStructTag(v.Value)
 	}
 
-	return "", errors.New("known TypeTag")
+	return "", errors.New("unknown TypeTag")
 }
 
 // TypeTagFromString parse string to TypeTag
@@ -307,8 +307,8 @@ func TypeTagFromString(str string) (types.TypeTag, error) {
 	case "address":
 		return &types.TypeTag__Address{}, nil
 	}
-	if strings.HasPrefix(str, "vector") {
-		substr := strings.TrimSuffix(strings.TrimPrefix(str, "vector<"), ">")
+	if strings.HasPrefix(str, "vector<") && strings.HasSuffix(str, ">") {
+		substr := str[7 : len(str)-1]
 		subTypeTag, err := TypeTagFromString(substr)
 		if err != nil {
 			return nil, err

--- a/api/exposed_test.go
+++ b/api/exposed_test.go
@@ -116,6 +116,10 @@ func TestTypeTagFromString_NestedVector(t *testing.T) {
 	require.IsType(t, &types.TypeTag__Vector{}, inner2.Value)
 	inner3 := inner2.Value.(*types.TypeTag__Vector)
 	require.IsType(t, &types.TypeTag__U8{}, inner3.Value)
+
+	// regression: "vectorFoo" should not be treated as a vector type
+	tag, err = TypeTagFromString("vectorFoo")
+	require.Error(t, err)
 }
 
 func TestDecodeMoveValue(t *testing.T) {

--- a/api/exposed_test.go
+++ b/api/exposed_test.go
@@ -83,6 +83,41 @@ func TestParseStructTag_Coin(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestStringifyTypeTag_UnknownError(t *testing.T) {
+	_, err := StringifyTypeTag(nil)
+	require.Error(t, err)
+	require.Equal(t, "unknown TypeTag", err.Error())
+}
+
+func TestTypeTagFromString_NestedVector(t *testing.T) {
+	// vector<u8>
+	tag, err := TypeTagFromString("vector<u8>")
+	require.NoError(t, err)
+	require.IsType(t, &types.TypeTag__Vector{}, tag)
+	inner := tag.(*types.TypeTag__Vector)
+	require.IsType(t, &types.TypeTag__U8{}, inner.Value)
+
+	// vector<vector<u8>>
+	tag, err = TypeTagFromString("vector<vector<u8>>")
+	require.NoError(t, err)
+	require.IsType(t, &types.TypeTag__Vector{}, tag)
+	inner = tag.(*types.TypeTag__Vector)
+	require.IsType(t, &types.TypeTag__Vector{}, inner.Value)
+	inner2 := inner.Value.(*types.TypeTag__Vector)
+	require.IsType(t, &types.TypeTag__U8{}, inner2.Value)
+
+	// vector<vector<vector<u8>>>
+	tag, err = TypeTagFromString("vector<vector<vector<u8>>>")
+	require.NoError(t, err)
+	require.IsType(t, &types.TypeTag__Vector{}, tag)
+	inner = tag.(*types.TypeTag__Vector)
+	require.IsType(t, &types.TypeTag__Vector{}, inner.Value)
+	inner2 = inner.Value.(*types.TypeTag__Vector)
+	require.IsType(t, &types.TypeTag__Vector{}, inner2.Value)
+	inner3 := inner2.Value.(*types.TypeTag__Vector)
+	require.IsType(t, &types.TypeTag__U8{}, inner3.Value)
+}
+
 func TestDecodeMoveValue(t *testing.T) {
 	store := NewLookup()
 


### PR DESCRIPTION
## Summary
- Fix typo: `"known TypeTag"` → `"unknown TypeTag"` in `StringifyTypeTag` error fallback
- Fix `TypeTagFromString` vector parsing to correctly handle nested types and reject non-vector prefixes

## Bug details

**Bug 1**: `StringifyTypeTag` returned `errors.New("known TypeTag")` for unrecognized variants — clearly should be "unknown".

**Bug 2**: `TypeTagFromString` used `strings.HasPrefix(str, "vector")` which would match any string starting with "vector" (e.g., a hypothetical struct `vectorFoo`). Changed to require both `vector<` prefix and `>` suffix, then extract inner type via `str[7:len(str)-1]`.

This correctly handles nested vectors:
- `vector<u8>` → inner: `u8`
- `vector<vector<u8>>` → inner: `vector<u8>` → recursion works

## Test plan
- [x] Added `TestStringifyTypeTag_UnknownError` — verifies corrected error message
- [x] Added `TestTypeTagFromString_NestedVector` — tests depth 1, 2, and 3 nested vectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the reported error message for unknown type-tag operations.
  * Strengthened validation for vector-type strings to require proper angle-bracket syntax.

* **Tests**
  * Added tests covering type-tag error messages, nested vector parsing, and a negative regression for malformed vector strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->